### PR TITLE
Add NodeManager service alias for autowiring

### DIFF
--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -1,4 +1,6 @@
 services:
+    Terminal42\NodeBundle\NodeManager: '@terminal42_node.manager'
+
     terminal42_node.manager:
         class: Terminal42\NodeBundle\NodeManager
         public: true


### PR DESCRIPTION
If you create a service, fragment, hook etc. in your App and want to use the `NodeManager` for your own content element or whatever the case may be, you currently have to define a `bind` for dependency injection, if you rely on autowiring. It would be convenient to already have the FQCN service alias defined in the extension itself so that you do not have to do that :)