### PR TITLE
Fix for DBAL 3 (Contao 4.13)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,8 @@
         "php": ">=7.1",
         "contao/core-bundle": "^4.4",
         "codefog/contao-haste": "^4.21",
-        "codefog/tags-bundle": "^3.0"
+        "codefog/tags-bundle": "^3.0",
+        "doctrine/dbal": "^2.13 || ^3.0"
     },
     "require-dev": {
         "terminal42/contao-geoip2-country": "^1.0",

--- a/src/EventListener/ContentListener.php
+++ b/src/EventListener/ContentListener.php
@@ -50,14 +50,14 @@ class ContentListener
             case 'edit':
             case 'delete':
             case 'show':
-                $nodeId = $this->db->fetchColumn('SELECT pid FROM tl_content WHERE id=? AND ptable=?', [$dc->id, 'tl_node']);
+                $nodeId = $this->db->fetchOne('SELECT pid FROM tl_content WHERE id=? AND ptable=?', [$dc->id, 'tl_node']);
                 break;
 
             case 'paste':
                 if ('create' === Input::get('mode')) {
                     $nodeId = $dc->id;
                 } else {
-                    $nodeId = $this->db->fetchColumn('SELECT pid FROM tl_content WHERE id=? AND ptable=?', [$dc->id, 'tl_node']);
+                    $nodeId = $this->db->fetchOne('SELECT pid FROM tl_content WHERE id=? AND ptable=?', [$dc->id, 'tl_node']);
                 }
                 break;
 
@@ -67,7 +67,7 @@ class ContentListener
             case 'cut':
             case 'cutAll':
                 if (1 === (int) Input::get('mode')) {
-                    $nodeId = $this->db->fetchColumn('SELECT pid FROM tl_content WHERE id=? AND ptable=?', [Input::get('pid'), 'tl_node']);
+                    $nodeId = $this->db->fetchOne('SELECT pid FROM tl_content WHERE id=? AND ptable=?', [Input::get('pid'), 'tl_node']);
                 } else {
                     $nodeId = Input::get('pid');
                 }
@@ -76,14 +76,14 @@ class ContentListener
             default:
                 // Ajax requests such as toggle
                 if (Input::get('cid')) {
-                    $nodeId = $this->db->fetchColumn('SELECT pid FROM tl_content WHERE id=? AND ptable=?', [Input::get('cid'), 'tl_node']);
+                    $nodeId = $this->db->fetchOne('SELECT pid FROM tl_content WHERE id=? AND ptable=?', [Input::get('cid'), 'tl_node']);
                 } else {
                     $nodeId = $dc->id;
                 }
                 break;
         }
 
-        $type = $this->db->fetchColumn('SELECT type FROM tl_node WHERE id=?', [$nodeId]);
+        $type = $this->db->fetchOne('SELECT type FROM tl_node WHERE id=?', [$nodeId]);
 
         // Throw an exception if the node is not present or is of a folder type
         if (!$type || NodeModel::TYPE_FOLDER === $type) {

--- a/src/EventListener/ContentListener.php
+++ b/src/EventListener/ContentListener.php
@@ -103,7 +103,7 @@ class ContentListener
         $ids = (array) StringUtil::deserialize($value, true);
 
         if (\count($ids) > 0) {
-            $folders = $this->db->fetchAll('SELECT name FROM tl_node WHERE id IN ('.implode(', ', $ids).') AND type=?', [NodeModel::TYPE_FOLDER]);
+            $folders = $this->db->fetchAllAssociative('SELECT name FROM tl_node WHERE id IN ('.implode(', ', $ids).') AND type=?', [NodeModel::TYPE_FOLDER]);
 
             // Do not allow folder nodes
             if (\count($folders) > 0) {

--- a/src/EventListener/DataContainerListener.php
+++ b/src/EventListener/DataContainerListener.php
@@ -170,7 +170,7 @@ class DataContainerListener
 
         // Make the button active only if there are subnodes
         if ($active) {
-            $active = $this->db->fetchColumn("SELECT COUNT(*) FROM $table WHERE pid=?", [$row['id']]) > 0;
+            $active = $this->db->fetchOne("SELECT COUNT(*) FROM $table WHERE pid=?", [$row['id']]) > 0;
         }
 
         return $this->generateButton($row, $href, $label, $title, $icon, $attributes, $active);
@@ -360,7 +360,7 @@ class DataContainerListener
             return;
         }
 
-        $type = $this->db->fetchColumn('SELECT type FROM tl_node WHERE id=?', [$dc->id]);
+        $type = $this->db->fetchOne('SELECT type FROM tl_node WHERE id=?', [$dc->id]);
 
         if (NodeModel::TYPE_CONTENT === $type) {
             $GLOBALS['TL_DCA'][$dc->table]['config']['switchToEdit'] = true;

--- a/src/PermissionChecker.php
+++ b/src/PermissionChecker.php
@@ -128,7 +128,7 @@ class PermissionChecker
 
         // Add the permissions on group level
         if ('custom' !== $user->inherit) {
-            $groups = $this->db->fetchAll('SELECT id, nodeMounts, nodePermissions FROM tl_user_group WHERE id IN('.implode(',', array_map('intval', $user->groups)).')');
+            $groups = $this->db->fetchAllAssociative('SELECT id, nodeMounts, nodePermissions FROM tl_user_group WHERE id IN('.implode(',', array_map('intval', $user->groups)).')');
 
             foreach ($groups as $group) {
                 $permissions = StringUtil::deserialize($group['nodePermissions'], true);


### PR DESCRIPTION
I am getting the following error, when I try to create a node in Contao 4.13.

![image](https://user-images.githubusercontent.com/87128053/151672865-d83eb1e8-fcc7-4000-887a-74e12322f6ce.png)

Contao 4.13 switched to DBAL 3 and doesnt support the method fetchColumn and fetchAll anymore.

https://www.doctrine-project.org/2020/11/17/dbal-3.0.0.html

I changed fetchColumn to fetchOne and fetchAll to fetchAllAssociative which results in the same behaviour.