### PR TITLE
Removed patchwork/utf8 from NodesContentElement.php

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "codefog/contao-haste": "^4.21",
         "codefog/tags-bundle": "^3.0",
         "doctrine/dbal": "^2.13 || ^3.0",
-        "symfony/string": "^5.4"
+        "symfony/string": "^5.4 || ^6.0"
     },
     "require-dev": {
         "terminal42/contao-geoip2-country": "^1.0",

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,8 @@
         "contao/core-bundle": "^4.4",
         "codefog/contao-haste": "^4.21",
         "codefog/tags-bundle": "^3.0",
-        "doctrine/dbal": "^2.13 || ^3.0"
+        "doctrine/dbal": "^2.13 || ^3.0",
+        "symfony/string": "^5.4"
     },
     "require-dev": {
         "terminal42/contao-geoip2-country": "^1.0",

--- a/src/ContentElement/NodesContentElement.php
+++ b/src/ContentElement/NodesContentElement.php
@@ -16,7 +16,6 @@ use Contao\BackendTemplate;
 use Contao\ContentElement;
 use Contao\StringUtil;
 use Contao\System;
-use Patchwork\Utf8;
 use Terminal42\NodeBundle\Model\NodeModel;
 
 class NodesContentElement extends ContentElement
@@ -96,7 +95,7 @@ class NodesContentElement extends ContentElement
             }
         }
 
-        $wildcard = '### '.Utf8::strtoupper($GLOBALS['TL_LANG']['FMD'][$data['type']][0]).' ###';
+        $wildcard = '### '.$GLOBALS['TL_LANG']['FMD'][$data['type']][0].' ###';
 
         // Add nodes
         if (\count($nodes) > 0) {

--- a/src/ContentElement/NodesContentElement.php
+++ b/src/ContentElement/NodesContentElement.php
@@ -16,6 +16,7 @@ use Contao\BackendTemplate;
 use Contao\ContentElement;
 use Contao\StringUtil;
 use Contao\System;
+use Symfony\Component\String\UnicodeString;
 use Terminal42\NodeBundle\Model\NodeModel;
 
 class NodesContentElement extends ContentElement
@@ -95,7 +96,8 @@ class NodesContentElement extends ContentElement
             }
         }
 
-        $wildcard = '### '.$GLOBALS['TL_LANG']['FMD'][$data['type']][0].' ###';
+		$type = new UnicodeString($GLOBALS['TL_LANG']['FMD'][$data['type']][0]);
+        $wildcard = '### '.$type->upper().' ###';
 
         // Add nodes
         if (\count($nodes) > 0) {

--- a/src/ContentElement/NodesContentElement.php
+++ b/src/ContentElement/NodesContentElement.php
@@ -96,8 +96,7 @@ class NodesContentElement extends ContentElement
             }
         }
 
-		$type = new UnicodeString($GLOBALS['TL_LANG']['FMD'][$data['type']][0]);
-        $wildcard = '### '.$type->upper().' ###';
+        $wildcard = '### '.(new UnicodeString($GLOBALS['TL_LANG']['FMD'][$data['type']][0]))->upper().' ###';
 
         // Add nodes
         if (\count($nodes) > 0) {


### PR DESCRIPTION
I got the following error in Contao 4.13 when I tried to open an article with a node element in backend.

![image](https://user-images.githubusercontent.com/87128053/151989325-146e1db2-6ae0-4411-86ea-1e952b147889.png)

strtoupper is not needed anymore because its done in CSS now. https://github.com/contao/contao/pull/3530