### PR TITLE
Fix return type of ContentListener

### DIFF
--- a/src/EventListener/ContentListener.php
+++ b/src/EventListener/ContentListener.php
@@ -98,7 +98,7 @@ class ContentListener
      *
      * @throws \InvalidArgumentException
      */
-    public function onNodesSaveCallback(?string $value, DataContainer $dc): string
+    public function onNodesSaveCallback(?string $value, DataContainer $dc): ?string
     {
         $ids = (array) StringUtil::deserialize($value, true);
         $ids = array_map('intval', $ids);


### PR DESCRIPTION
The value passed to the `save_callback` can be null for non-mandatory node selections, e.g.

```php
$GLOBALS['TL_DCA']['tl_foobar']['fields']['nodes'] = [
    'label' => &$GLOBALS['TL_LANG']['tl_content']['nodes'],
    'exclude' => true,
    'inputType' => 'nodePicker',
    'eval' => ['multiple' => true, 'fieldType' => 'checkbox', 'tl_class' => 'clr'],
    'sql' => ['type' => 'blob', 'notnull' => false],
    'save_callback' => [
        ['terminal42_node.listener.content', 'onNodesSaveCallback'],
    ],
];
```

However, currently the callback method has a `string` return type which leads to the following error:

```
TypeError:
Terminal42\NodeBundle\EventListener\ContentListener::onNodesSaveCallback(): Return value must be of type string, null returned

  at vendor\terminal42\contao-node\src\EventListener\ContentListener.php:121
  at Terminal42\NodeBundle\EventListener\ContentListener->onNodesSaveCallback(null, object(DC_Table))
     (vendor\contao\contao\core-bundle\src\Resources\contao\drivers\DC_Table.php:3288)
  at Contao\DC_Table->save(null)
     (vendor\contao\contao\core-bundle\src\Resources\contao\classes\DataContainer.php:523)
  at Contao\DataContainer->row('{address_group_legend},name;{address_group_content_legend},nodes')
     (vendor\contao\contao\core-bundle\src\Resources\contao\drivers\DC_Table.php:1979)
  at Contao\DC_Table->edit()
     (vendor\contao\contao\core-bundle\src\Resources\contao\classes\Backend.php:667)
  at Contao\Backend->getBackendModule('address_verification', null)
     (vendor\contao\contao\core-bundle\src\Resources\contao\controllers\BackendMain.php:168)
  at Contao\BackendMain->run()
     (vendor\contao\contao\core-bundle\src\Controller\BackendController.php:49)
  at Contao\CoreBundle\Controller\BackendController->mainAction()
     (vendor\symfony\http-kernel\HttpKernel.php:163)
  at Symfony\Component\HttpKernel\HttpKernel->handleRaw(object(Request), 1)
     (vendor\symfony\http-kernel\HttpKernel.php:75)
  at Symfony\Component\HttpKernel\HttpKernel->handle(object(Request), 1, true)
     (vendor\symfony\http-kernel\Kernel.php:202)
  at Symfony\Component\HttpKernel\Kernel->handle(object(Request))
     (public\index.php:44)               
```