### PR TITLE
Fix error when loading DI extension

### DIFF
--- a/src/DependencyInjection/Terminal42NodeExtension.php
+++ b/src/DependencyInjection/Terminal42NodeExtension.php
@@ -16,7 +16,7 @@ class Terminal42NodeExtension extends Extension
 {
     public function load(array $configs, ContainerBuilder $container): void
     {
-        $loader = new YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
+        $loader = new YamlFileLoader($container, new FileLocator(__DIR__.'/../../config'));
         $loader->load('services.yml');
 
         if (class_exists(DcaLoaderListener::class)) {


### PR DESCRIPTION
Currently the following error occurs:

```
The file "services.yml" does notexist (in: "vendor\terminal42\contao-node\src\DependencyInjection/../Resources/config").
```

this PR fixes that.