### PR TITLE
Fix warning in debug mode when saving a `tl_module.node` field

### DIFF
--- a/src/EventListener/ContentListener.php
+++ b/src/EventListener/ContentListener.php
@@ -96,7 +96,7 @@ class ContentListener
             $ids = array_map('intval', $ids);
 
             // Check for potential circular reference
-            if ('tl_node' === $dc->activeRecord->ptable && \in_array((int) $dc->activeRecord->pid, $ids, true)) {
+            if ('tl_node' === ($dc->activeRecord->ptable ?? null) && \in_array((int) $dc->activeRecord->pid, $ids, true)) {
                 throw new \InvalidArgumentException($GLOBALS['TL_LANG']['ERR']['circularReference']);
             }
         }


### PR DESCRIPTION
When the debug mode is enabled and you create a new front end module with nodes (e.g. `mod_nodes`), it cannot be saved as a warning occurs on save since `$this->activeRecord->ptable` will not exist for the `tl_module` DataContainer. This PR fixes that.