### PR TITLE
Fix the execution order for language files

### DIFF
--- a/contao/dca/tl_module.php
+++ b/contao/dca/tl_module.php
@@ -3,8 +3,8 @@
 use Contao\Controller;
 use Contao\System;
 
-Controller::loadDataContainer('tl_content');
 System::loadLanguageFile('tl_content');
+Controller::loadDataContainer('tl_content');
 
 // Palettes
 $GLOBALS['TL_DCA']['tl_module']['palettes']['__selector__'][] = 'nodesWrapper';

--- a/contao/dca/tl_user_group.php
+++ b/contao/dca/tl_user_group.php
@@ -4,8 +4,8 @@ use Contao\Controller;
 use Contao\CoreBundle\DataContainer\PaletteManipulator;
 use Contao\System;
 
-Controller::loadDataContainer('tl_user');
 System::loadLanguageFile('tl_user');
+Controller::loadDataContainer('tl_user');
 
 // Palettes
 PaletteManipulator::create()


### PR DESCRIPTION
See https://github.com/terminal42/contao-node/issues/64#issuecomment-4004818847

The order of execution matters, especially if multiple extensions call `System::loadLanguageFile()` and `Controller::loadDataContainer()` in their own, _different_ DCA files.